### PR TITLE
main/Faikin: Increase serial timeout

### DIFF
--- a/main/Faikin.c
+++ b/main/Faikin.c
@@ -465,6 +465,9 @@ enum
    S21_WAIT,
 };
 
+// Timeout value for serial port read
+#define READ_TIMEOUT (500 / portTICK_PERIOD_MS)
+
 int
 daikin_s21_command (uint8_t cmd, uint8_t cmd2, int txlen, char *payload)
 {
@@ -503,7 +506,7 @@ daikin_s21_command (uint8_t cmd, uint8_t cmd2, int txlen, char *payload)
    }
    uart_write_bytes (uart, buf, 5 + txlen);
    // Wait ACK
-   int rxlen = uart_read_bytes (uart, &temp, 1, 100 / portTICK_PERIOD_MS);
+   int rxlen = uart_read_bytes (uart, &temp, 1, READ_TIMEOUT);
    if (rxlen != 1 || (temp != ACK && temp != STX))
    {
       jo_t j = jo_comms_alloc ();
@@ -538,7 +541,7 @@ daikin_s21_command (uint8_t cmd, uint8_t cmd2, int txlen, char *payload)
          return S21_OK;         // No response expected
       while (1)
       {
-         rxlen = uart_read_bytes (uart, buf, 1, 100 / portTICK_PERIOD_MS);
+         rxlen = uart_read_bytes (uart, buf, 1, READ_TIMEOUT);
          if (rxlen != 1)
          {
             daikin.talking = 0;
@@ -553,7 +556,7 @@ daikin_s21_command (uint8_t cmd, uint8_t cmd2, int txlen, char *payload)
    }
    while (rxlen < sizeof (buf))
    {
-      if (uart_read_bytes (uart, buf + rxlen, 1, 10 / portTICK_PERIOD_MS) != 1)
+      if (uart_read_bytes (uart, buf + rxlen, 1, READ_TIMEOUT) != 1)
       {
          daikin.talking = 0;
          jo_t j = jo_comms_alloc ();
@@ -652,7 +655,7 @@ daikin_command (uint8_t cmd, int txlen, uint8_t * payload)
    }
    uart_write_bytes (uart, buf, 6 + txlen);
    // Wait for reply
-   int rxlen = uart_read_bytes (uart, buf, sizeof (buf), 100 / portTICK_PERIOD_MS);
+   int rxlen = uart_read_bytes (uart, buf, sizeof (buf), READ_TIMEOUT);
    if (rxlen <= 0)
    {
       daikin.talking = 0;


### PR DESCRIPTION
Original timeout value appears too small, long packets aren't received. Bump up to 500 ticks, introduce a macro to prevent errors (note 10 instead of 100 in one location)

Faikin now works with my AC.