### PR TITLE
main/Faikin.c: Fix missing "powerful" state update

### DIFF
--- a/faikin-s21.c
+++ b/faikin-s21.c
@@ -132,6 +132,7 @@ main(int argc, const char *argv[])
 	  {"fan", 0, POPT_ARG_INT, &fan, 0, "Fan", "0 = auto, 1-5 = set speed, 6 = quiet"},
 	  {"temp", 0, POPT_ARG_FLOAT, &temp, 0, "Temp", "C"},
 	  {"comp", 0, POPT_ARG_INT, &comp, 0, "Comp", "1=H,2=C"},
+	  {"powerful", 0, POPT_ARG_NONE, &powerful, 0, "Debug"},
 	  {"dump", 'V', POPT_ARG_NONE, &dump, 0, "Dump"},
 	  POPT_AUTOHELP {}
    };

--- a/main/Faikin.c
+++ b/main/Faikin.c
@@ -1237,6 +1237,7 @@ web_root (httpd_req_t * req)
                              "b('swingh',o.swingh);"    //
                              "b('swingv',o.swingv);"    //
                              "b('econo',o.econo);"      //
+                             "b('powerful',o.powerful);"
                              "e('mode',o.mode);"        //
                              "s('Temp',(o.home?o.home+'℃':'---')+(o.env?' / '+o.env+'℃':''));"      //
                              "n('temp',o.temp);"        //


### PR DESCRIPTION
Fix update of the switch state on the web page. Add option to S21 simulator for easy testing
