### PR TITLE
More robust S21

### DIFF
--- a/ESP32/main/Faikin.c
+++ b/ESP32/main/Faikin.c
@@ -459,7 +459,6 @@ daikin_s21_response (uint8_t cmd, uint8_t cmd2, int len, uint8_t * payload)
                break;
             }
          }
->>>>>>> d7a6c34 (More flexible S21):main/Faikin.c
       }
    }
    return S21_OK;
@@ -712,7 +711,7 @@ daikin_s21_command (uint8_t cmd, uint8_t cmd2, int txlen, char *payload)
       protocol_found ();
    // An expected S21 reply contains the first character of the command
    // incremented by 1, the second character is left intact
-   if (rxlen < S21_MIN_PKT_LEN || buf[0] != STX || buf[rxlen - 1] != ETX || buf[1] != cmd + 1 || buf[2] != cmd2)
+   if (rxlen < S21_MIN_PKT_LEN || buf[S21_STX_OFFSET] != STX || buf[rxlen - 1] != ETX || buf[S21_CMD0_OFFSET] != cmd + 1 || buf[S21_CMD1_OFFSET] != cmd2)
    {
       // Malformed response, no proper S21
       daikin.talking = 0;       // Protocol is broken, will restart communication
@@ -725,7 +724,7 @@ daikin_s21_command (uint8_t cmd, uint8_t cmd2, int txlen, char *payload)
       revk_error ("comms", &j);
       return S21_BAD;
    }
-   return daikin_s21_response (buf[1], buf[2], rxlen - 5, buf + 3);
+   return daikin_s21_response (buf[S21_CMD0_OFFSET], buf[S21_CMD1_OFFSET], rxlen - S21_MIN_PKT_LEN, buf + S21_PAYLOAD_OFFSET);
 }
 
 void

--- a/ESP32/main/Faikin.c
+++ b/ESP32/main/Faikin.c
@@ -332,6 +332,21 @@ enum
    S21_WAIT,
 };
 
+static int
+check_length(uint8_t cmd, uint8_t cmd2, int len, int required, const uint8_t * payload)
+{
+   if (len >= required)
+      return 1;
+
+   jo_t j = jo_comms_alloc ();
+   jo_stringf (j, "badlength", "%d", len);
+   jo_stringf (j, "command", "%c%c", cmd, cmd2);
+   jo_base16 (j, "data", payload, len);
+   revk_error ("comms", &j);
+
+   return 0;
+}
+
 // Decode S21 response payload
 int
 daikin_s21_response (uint8_t cmd, uint8_t cmd2, int len, uint8_t * payload)
@@ -342,82 +357,109 @@ daikin_s21_response (uint8_t cmd, uint8_t cmd2, int len, uint8_t * payload)
       jo_stringn (s21debug, tag, (char *) payload, len);
    }
    // Remember to add to polling if we add more handlers
-   if (cmd == 'G' && len == 4)
+   if (cmd == 'G')
       switch (cmd2)
       {
       case '1':                // 'G1' - basic status
-         set_val (online, 1);
-         set_val (power, (payload[0] == '1') ? 1 : 0);
-         set_val (mode, "30721003"[payload[1] & 0x7] - '0');    // FHCA456D mapped from AXDCHXF
-         set_val (heat, daikin.mode == 1);      // Crude - TODO find if anything actually tells us this
-         if (daikin.mode == 1 || daikin.mode == 2 || daikin.mode == 3)
-            set_temp (temp, s21_decode_target_temp (payload[2]));
-         else if (!isnan (daikin.temp))
-            set_temp (temp, daikin.temp);       // Does not have temp in other modes
-         if (payload[3] != 'A') // Set fan speed
-            set_val (fan, "00012345"[payload[3] & 0x7] - '0');  // XXX12345 mapped to A12345Q
-         else if (daikin.fan == 6)
-            set_val (fan, 6);   // Quiet mode set (it returns as auto, so we assume it set to quiet if not powered on)
-         else if (!daikin.power || !daikin.fan || daikin.fanrpm >= 750)
-            set_val (fan, 0);   // Auto as fan too fast to be quiet mode
+         if (check_length(cmd, cmd2, len, S21_PAYLOAD_LEN, payload))
+         {
+            set_val (online, 1);
+            set_val (power, (payload[0] == '1') ? 1 : 0);
+            set_val (mode, "30721003"[payload[1] & 0x7] - '0');    // FHCA456D mapped from AXDCHXF
+            set_val (heat, daikin.mode == 1);      // Crude - TODO find if anything actually tells us this
+            if (daikin.mode == 1 || daikin.mode == 2 || daikin.mode == 3)
+               set_temp (temp, s21_decode_target_temp (payload[2]));
+            else if (!isnan (daikin.temp))
+               set_temp (temp, daikin.temp);       // Does not have temp in other modes
+            if (payload[3] != 'A') // Set fan speed
+               set_val (fan, "00012345"[payload[3] & 0x7] - '0');  // XXX12345 mapped to A12345Q
+            else if (daikin.fan == 6)
+               set_val (fan, 6);   // Quiet mode set (it returns as auto, so we assume it set to quiet if not powered on)
+            else if (!daikin.power || !daikin.fan || daikin.fanrpm >= 750)
+               set_val (fan, 0);   // Auto as fan too fast to be quiet mode
+         }
          break;
       case '3':                // Seems to be an alternative to G6
-         set_val (powerful, payload[3] & 0x02 ? 1 : 0);
+         if (check_length(cmd, cmd2, len, 1, payload))
+         {
+            set_val (powerful, payload[3] & 0x02 ? 1 : 0);
+         }
          break;
       case '5':                // 'G5' - swing status
-         set_val (swingv, (payload[0] & 1) ? 1 : 0);
-         set_val (swingh, (payload[0] & 2) ? 1 : 0);
+         if (check_length(cmd, cmd2, len, 1, payload))
+         {
+            set_val (swingv, (payload[0] & 1) ? 1 : 0);
+            set_val (swingh, (payload[0] & 2) ? 1 : 0);
+         }
          break;
       case '6':                // 'G6' - "powerful" mode and some others
-         set_val (powerful, payload[0] & 0x02 ? 1 : 0);
-         set_val (comfort, payload[0] & 0x40 ? 1 : 0);
-         set_val (quiet, payload[0] & 0x80 ? 1 : 0);
-         set_val (streamer, payload[1] & 0x80 ? 1 : 0);
-         set_val (sensor, payload[3] & 0x08 ? 1 : 0);
+         if (check_length(cmd, cmd2, len, S21_PAYLOAD_LEN, payload))
+         {
+            set_val (powerful, payload[0] & 0x02 ? 1 : 0);
+            set_val (comfort, payload[0] & 0x40 ? 1 : 0);
+            set_val (quiet, payload[0] & 0x80 ? 1 : 0);
+            set_val (streamer, payload[1] & 0x80 ? 1 : 0);
+            set_val (sensor, payload[3] & 0x08 ? 1 : 0);
+         }
          break;
       case '7':                // 'G7' - "eco" mode
-         set_val (econo, payload[1] & 0x02 ? 1 : 0);
+         if (check_length(cmd, cmd2, len, 2, payload))
+         {
+            set_val (econo, payload[1] & 0x02 ? 1 : 0);
+         }
          break;
       case '9':
-         set_temp (home, (float) ((signed) payload[0] - 0x80) / 2);
-         set_temp (outside, (float) ((signed) payload[1] - 0x80) / 2);
-         break;
-
-      }
-   if (cmd == 'S' && len == 4)
-   {
-      float t = (payload[0] - '0') * 0.1 + (payload[1] - '0') + (payload[2] - '0') * 10;
-      if (payload[3] == '-')
-         t = -t;
-      if (t < 100)              // Sanity check
-         switch (cmd2)
-         {                      // Temperatures (guess)
-         case 'H':             // 'SH' - home temp
-            set_temp (home, t);
-            break;
-         case 'a':             // 'Sa' - outside temp
-            set_temp (outside, t);
-            break;
-         case 'I':             // 'SI' - liquid ???
-            set_temp (liquid, t);
-            break;
-         case 'N':             // ?
-            break;
-         case 'X':             // ?
-            break;
+         if (check_length(cmd, cmd2, len, 2, payload))
+         {
+            set_temp (home, (float) ((signed) payload[0] - 0x80) / 2);
+            set_temp (outside, (float) ((signed) payload[1] - 0x80) / 2);
          }
-   }
-   if (cmd == 'S' && len == 3)
+         break;
+      }
+   if (cmd == 'S')
    {
-      int v = (payload[0] - '0') + (payload[1] - '0') * 10 + (payload[2] - '0') * 100;
-      switch (cmd2)
+      if (cmd2 == 'L' || cmd2 == 'd')
       {
-      case 'L':                // Fan
-         set_int (fanrpm, v * 10);
-         break;
-      case 'd':                // Compressor
-         set_int (comp, v);
-         break;
+         // These responses are always only 3 bytes long
+         if (check_length(cmd, cmd2, len, 3, payload))
+         {
+            int v = s21_decode_int_sensor(payload) * 10;
+
+            switch (cmd2)
+            {
+            case 'L':                // Fan
+               set_int (fanrpm, v * 10);
+               break;
+            case 'd':                // Compressor
+               set_int (comp, v);
+               break;
+            }
+         }
+      }
+      else if (check_length(cmd, cmd2, len, S21_PAYLOAD_LEN, payload))
+      {
+         float t = s21_decode_float_sensor(payload);
+
+         if (t < 100)              // Sanity check
+         {
+            switch (cmd2)
+            {                      // Temperatures (guess)
+            case 'H':             // 'SH' - home temp
+               set_temp (home, t);
+               break;
+            case 'a':             // 'Sa' - outside temp
+               set_temp (outside, t);
+               break;
+            case 'I':             // 'SI' - liquid ???
+               set_temp (liquid, t);
+               break;
+            case 'N':             // ?
+               break;
+            case 'X':             // ?
+               break;
+            }
+         }
+>>>>>>> d7a6c34 (More flexible S21):main/Faikin.c
       }
    }
    return S21_OK;
@@ -618,6 +660,7 @@ daikin_s21_command (uint8_t cmd, uint8_t cmd2, int txlen, char *payload)
          loopback = 0;
          jo_t j = jo_comms_alloc ();
          jo_bool (j, "timeout", 1);
+         jo_base16 (j, "data", buf, rxlen);
          revk_error ("comms", &j);
          return S21_NOACK;
       }

--- a/ESP32/main/daikin_s21.h
+++ b/ESP32/main/daikin_s21.h
@@ -18,6 +18,8 @@
 #define S21_CMD0_OFFSET    1
 #define S21_CMD1_OFFSET    2
 #define S21_PAYLOAD_OFFSET 3
+
+// A typical payload length, but there are deviations
 #define S21_PAYLOAD_LEN    4
 
 // A minimum length of a packet (with no payload)
@@ -63,6 +65,17 @@ static inline float s21_decode_target_temp(unsigned char v)
 static inline float s21_encode_target_temp(float temp)
 {
    return lroundf((temp - 18.0) * 2) + AC_MIN_TEMP_VALUE;
+}
+
+static inline int s21_decode_int_sensor(const unsigned char * payload)
+{
+   return (payload[0] - '0') + (payload[1] - '0') * 10 + (payload[2] - '0') * 100;
+}
+
+static inline float s21_decode_float_sensor(const unsigned char * payload)
+{
+   float v = s21_decode_int_sensor(payload) * 0.1;
+   return payload[3] == '-' ? -v : v;
 }
 
 // Convert between Daikin and Faikin fan speed enums


### PR DESCRIPTION
Rewrite daikin_s21_response() to only check against minimum required
payload length. In case of a mismatch, an error message will be emitted
over MQTT.

Dump partially received data in "timeout" messages; this may help to pinpoint
where exactly the error occurs

These changes make S21 implementation more robust and ease debugging

Signed-off-by: Pavel Fedin <pavel_fedin@mail.ru>
