### PR TITLE
Fix for incorrect type for s21_nak()

### DIFF
--- a/Tools/faikin-s21.c
+++ b/Tools/faikin-s21.c
@@ -68,7 +68,7 @@ static void serial_write(int p, const unsigned char *response, unsigned int pkt_
    }
 }
 
-static void s21_nak(int p, char *buf)
+static void s21_nak(int p, unsigned char *buf)
 {
    static unsigned char response = NAK;
 


### PR DESCRIPTION
I was getting compiler type warnings when building `faikin-s21.c`.
This fixed it.
