### PR TITLE
S21 simulator build fixes

### DIFF
--- a/Tools/Makefile
+++ b/Tools/Makefile
@@ -46,7 +46,7 @@ faikin: faikin.c
 	gcc -O -o $@ $< -lpopt ${INCLUDES} ${LIBS}
 
 faikin-s21: faikin-s21.c ../ESP32/main/daikin_s21.h ../ESP32/main/faikin_enums.h
-	gcc -O0 -g -o $@ $< -lpopt ${INCLUDES} ${LIBS}
+	gcc -O0 -g -o $@ $< -lpopt -lm ${INCLUDES} ${LIBS}
 
 faikinlog: faikinlog.c SQLlib/sqllib.o AJL/ajl.o ../ESP32/main/acextras.m ../ESP32/main/acfields.m ../ESP32/main/accontrols.m
 	cc -O -o $@ $< -lpopt -lmosquitto -ISQLlib SQLlib/sqllib.o -IAJL AJL/ajl.o ${INCLUDES} ${OPTS}

--- a/Tools/Makefile
+++ b/Tools/Makefile
@@ -18,7 +18,7 @@ endif
 ifdef	SQLINC
 TOOLS := faikin faikinlog faikingraph
 else
-$(error Warning - mariadb/mysql not installed, needed if you want to build tools)
+$(warning Warning - mariadb/mysql not installed, needed if you want to build tools)
 endif
 
 tools:	$(TOOLS)

--- a/Tools/Makefile
+++ b/Tools/Makefile
@@ -15,8 +15,9 @@ SQLLIB=$(shell mariadb_config --libs)
 SQLVER=$(shell mariadb_config --version | sed 'sx\..*xx')
 endif
 
+TOOLS := faikin faikin-s21
 ifdef	SQLINC
-TOOLS := faikin faikinlog faikingraph
+TOOLS += faikinlog faikingraph
 else
 $(warning Warning - mariadb/mysql not installed, needed if you want to build tools)
 endif

--- a/Tools/Makefile
+++ b/Tools/Makefile
@@ -25,11 +25,11 @@ endif
 tools:	$(TOOLS)
 
 ifeq ($(shell uname),Darwin)
-INCLUDES=-I/usr/local/include/ -I$(shell brew --prefix)/include/ -I../ESP32/main
+INCLUDES=-I/usr/local/include/ -I$(shell brew --prefix)/include/ -I../ESP32/
 LIBS=-L$(shell brew --prefix)/lib/
 else
 LIBS=
-INCLUDES=-I../ESP32/main
+INCLUDES=-I../ESP32/
 endif
 
 SQLlib/sqllib.o: SQLlib/sqllib.c

--- a/Tools/Makefile
+++ b/Tools/Makefile
@@ -25,8 +25,8 @@ endif
 tools:	$(TOOLS)
 
 ifeq ($(shell uname),Darwin)
-INCLUDES=-I/usr/local/include/ -I../ESP32/main
-LIBS=-L/usr/local/Cellar/popt/1.18/lib/
+INCLUDES=-I/usr/local/include/ -I$(shell brew --prefix)/include/ -I../ESP32/main
+LIBS=-L$(shell brew --prefix)/lib/
 else
 LIBS=
 INCLUDES=-I../ESP32/main

--- a/Tools/faikin-s21.c
+++ b/Tools/faikin-s21.c
@@ -11,6 +11,8 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <stdint.h>
+#include <errno.h>
+#include <err.h>
 
 #include "main/daikin_s21.h"
 


### PR DESCRIPTION
These changes allowed me to build the `faikin-s21` Simulator Tool on both Mac and Linux.

I have done these as a series of commits to make the PR easier to breakdown:
- Allow building tools that don't depend on MySQL, if MySQL isn't installed
- Use the `brew --prefix` command to find Homebrew - rather than assuming `libpopt` is at specific path
- Fix for `daikin_s21.h` search path - I am not sure why `main` was both in the `#include` path and search path
- Added missing includes / libm that are needed to build on Linux
