### PR TITLE
ESP32: Introduce build.bat for use under Windows

### DIFF
--- a/ESP32/build.bat
+++ b/ESP32/build.bat
@@ -1,0 +1,33 @@
+@echo off
+
+setlocal
+
+IF NOT DEFINED POSIX_ENV_PATH (
+  REM some commonly used defaults
+  IF EXIST "c:\msys64\usr\bin" (
+    set POSIX_ENV_PATH=c:\msys64\usr\bin
+  ) ELSE IF EXIST "c:\cygwin64\usr\bin" (
+    set POSIX_ENV_PATH=c:\cygwin64\usr\bin
+  ) ELSE IF EXIST "c:\cygwin\usr\bin" (
+    set POSIX_ENV_PATH=c:\cygwin\usr\bin
+  ) ELSE (
+    echo Cygwin or MSYS not found! Install or provide POSIX_ENV_PATH environment variable
+    goto end
+  )
+)
+
+set "PATH=%PATH%;%POSIX_ENV_PATH%"
+
+set PROJECT_NAME=Faikin
+for /f %%i in ('csh components/ESP32-RevK/buildsuffix') do set SUFFIX=%%i
+
+echo Building: %PROJECT_NAME%%SUFFIX%.bin
+
+make settings.h
+idf.py build
+
+copy /Y build\%PROJECT_NAME%.bin %PROJECT_NAME%%SUFFIX%.bin
+copy /Y build\bootloader\bootloader.bin %PROJECT_NAME%%SUFFIX%-bootloader.bin
+echo Done: %PROJECT_NAME%%SUFFIX%.bin
+
+:end


### PR DESCRIPTION
Our build uses some auxiliary tools, which are also built from C sources in the process. Unfortunately Windows version of ESP32-IDF decided to ditch MinGW, and comes with a naked Windows cmd.exe shell with a minimalist set of tools (idf.py, git, and that's all). It's not possible to run idf.py from e. g. MinGW prompt; it doesn't allow doing that.

Our auxiliary tools require a full POSIX environment with gcc and make.

Work around IDF limitations by introducing a bridge script, which relies on a side-by-side installation of a POSIX environment, such as MSYS or Cygwin. Our auxiliary tools are now run via that environment, while idf.py keeps living in pure Windows, as it wants.