### PR TITLE
Update release falsh README.md to include note for different bootloader addresses.

### DIFF
--- a/ESP32/release/README.md
+++ b/ESP32/release/README.md
@@ -12,6 +12,7 @@ You need `esptool`
 
 - The `Faikin-S1-PICO-bootloader.bin` needs to be the relevant release bootloader binary file for the chip used.
 - The `Faikin-S1-PICO.bin` needs to be the relevant release binary file for the chip used.
+- The bootloader address differs between ESP32 versions S1 and S3. For the S1 versions the bootloader is located at 0x1000. For the S3 models this needs to be changed to 0x0.
 
 ## 8266 port
 


### PR DESCRIPTION
Added note for different bootloader addresses. I found that the address for the S3 chip on the newer models is different than for the S1 (https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-guides/bootloader.html).