### PR TITLE
Set device_class property to "energy" for the Lifetime energy entity

### DIFF
--- a/ESP/main/Faikin.c
+++ b/ESP/main/Faikin.c
@@ -2458,6 +2458,7 @@ send_ha_config (void)
       {
          jo_t j = make ("energy", NULL);
          jo_string (j, "name", "Lifetime energy");
+         jo_string (j, "dev_cla", "energy");
          jo_string (j, "stat_t", revk_id);
          jo_string (j, "unit_of_meas", "kWh");
          jo_string (j, "state_class", "total_increasing");


### PR DESCRIPTION
I added the device_class property for the energy measurement so it can be used in the Home Assistant energy dashboard. 

Without it you see this error message:
![Screenshot_20240515_133855](https://github.com/revk/ESP32-Faikin/assets/753028/3ce25edb-5292-4a64-a49f-51d310c56b36)
