### PR TITLE
Attempt at fixing CN_WIRED transmission

### DIFF
--- a/ESP/main/Faikin.c
+++ b/ESP/main/Faikin.c
@@ -571,6 +571,10 @@ daikin_cn_wired_response (int len, uint8_t * payload)
 {                               // Process response
    if (len != CN_WIRED_LEN)
       return;
+
+   // We're now online
+   report_uint8 (online, 1);
+
    if (!protocol_set)
    {
       // Protocol autodetection complete
@@ -609,7 +613,6 @@ daikin_cn_wired_response (int len, uint8_t * payload)
       jo_base16 (j, "dump", payload, len);
       revk_error ("rx", &j);
    }
-   daikin.control_changed = 0;  // Assume all updated
 }
 
 void


### PR DESCRIPTION
Found a problem with new RMT driver, which doesn't allow us to properly specify tx idle state as high. Worked around by using line inversion. Fixed internal status handling. CN_WIRED verified to work with simulator with the following settings:
nox21 = true
nox50a = true
nocnwired = false
noas = true
noswaptx = true
noswaprx = true

Protocols other than cn_wired disabled for speed; autodetection is expected to work. Inversion is disabled because my development board has non-inverted outputs. Autodetection should work after all previous fixes, but untested.