### PR TITLE
ESP/Makefile: Update only top-level modules to new versions

### DIFF
--- a/ESP/Makefile
+++ b/ESP/Makefile
@@ -85,7 +85,8 @@ pull:
 
 update:
 	-git pull
-	git submodule update --init --recursive --remote
+	git submodule update --init --remote
+	git submodule update --recursive
 	-git commit -a -m "Library update"
 	-git push
 


### PR DESCRIPTION
Only "ours" modules need to be updated to tips on "make update". Proper versions of nested submodules is determined by their parents, who store super-pointers individually.