### PR TITLE
Simulators/faikin-s21: Protocol v2 support

### DIFF
--- a/ESP/main/daikin_s21.h
+++ b/ESP/main/daikin_s21.h
@@ -19,11 +19,12 @@
 #define S21_CMD1_OFFSET    2
 #define S21_PAYLOAD_OFFSET 3
 
+// Length of a framing (STX + CRC + ETX)
+#define S21_FRAMING_LEN 3
 // A typical payload length, but there are deviations
-#define S21_PAYLOAD_LEN    4
-
-// A minimum length of a packet (with no payload)
-#define S21_MIN_PKT_LEN 5
+#define S21_PAYLOAD_LEN 4
+// A minimum length of a packet (with no payload): framing + CMD0 + CMD1
+#define S21_MIN_PKT_LEN S21_FRAMING_LEN + 2
 
 // Encoding for minimum target temperature value, correspond to 18 deg.C.
 #define AC_MIN_TEMP_VALUE '@'


### PR DESCRIPTION
Added commands to support protocol v2, as expected by BRP069B41. Successfully goes online. More comments for what has been figured out.