### PR TITLE
ESP: Introduce udp_discovery setting

### DIFF
--- a/ESP/main/Faikin.c
+++ b/ESP/main/Faikin.c
@@ -3028,7 +3028,9 @@ app_main ()
 #include "acextras.m"
    revk_boot (&mqtt_client_callback);
    revk_start ();
-   revk_task ("daikin_discovery", legacy_discovery_task, NULL, 0);
+
+   if (udp_discovery)
+      revk_task ("daikin_discovery", legacy_discovery_task, NULL, 0);
 
    b.dumping = dump;
    revk_blink (0, 0, "");

--- a/ESP/settings.def
+++ b/ESP/settings.def
@@ -36,6 +36,8 @@ bit	no.fanauto								// Do not control fan in faikin auto mode
 bit	no.homepreset								// Do not include a home in HA preset list
 bit	no.icons			.live=1					// Do not show icons on web UI
 
+bit udp_discovery                           // Enable Daikin BRP-compatible UDP discovery
+
 bit	dark									// Dark mode
 bit	ha.enable	1		.old="ha"				// Home Assistance
 bit	ha.switches								// Set additional HA switches


### PR DESCRIPTION
It turns out that our legacy API isn't completely properly done; and it appears to disrupt Daikin app's advanced functionality (like power saving modes), causing it to crash.

Let's mitigate that by introducing a setting, which allows for enable or disable auto-discovery on demand. Defaults to off since the feature is currently experimental.